### PR TITLE
feat: add level designer and enemies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+package-lock.json
+.env
+
+# build
+build/
+dist/
+

--- a/levels/level1.json
+++ b/levels/level1.json
@@ -19,6 +19,6 @@
   "skybox": { "url": "/assets/skyboxes/level1.jpg", "source": "user" },
   "spawn": { "x": 2, "y": 2 },
   "goal": { "x": 2, "y": 4 },
-  "entities": [],
+  "enemies": [{ "x": 1, "y": 3 }],
   "meta": { "difficulty": "easy", "version": 1 }
 }

--- a/src/game-engine.ts
+++ b/src/game-engine.ts
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import playerModelUrl from './player.glb?url';
 
 export async function initAmmo(): Promise<void> {
   pc.WasmModule.setConfig('Ammo', {
@@ -22,4 +23,111 @@ export function createApp(canvas: HTMLCanvasElement): pc.Application {
 
   app.start();
   return app;
+}
+
+async function loadGlb(app: pc.Application, url: string): Promise<pc.Entity> {
+  return await new Promise((resolve, reject) => {
+    app.assets.loadFromUrl(url, 'container', (err, asset) => {
+      if (err || !asset) {
+        reject(err);
+        return;
+      }
+      const entity = (asset as pc.Asset).resource.instantiateRenderEntity();
+      resolve(entity);
+    });
+  });
+}
+
+export interface LevelData {
+  width: number;
+  height: number;
+  grid: string[];
+  spawn: { x: number; y: number };
+  goal: { x: number; y: number };
+  enemies?: { x: number; y: number }[];
+  palette?: { background?: string; primary?: string; accent?: string };
+}
+export function buildLevel(
+  app: pc.Application,
+  level: LevelData
+): { spawn: pc.Vec3; goal: pc.Entity; enemies: pc.Vec3[] } {
+  const cellSize = 1;
+  const offsetX = -(level.width * cellSize) / 2 + cellSize / 2;
+  const offsetZ = -(level.height * cellSize) / 2 + cellSize / 2;
+
+  for (let y = 0; y < level.height; y++) {
+    const row = level.grid[y];
+    for (let x = 0; x < level.width; x++) {
+      const ch = row[x];
+      if (ch === 'S') {
+        const block = new pc.Entity(`block-${x}-${y}`);
+        block.addComponent('render', { type: 'box' });
+        block.addComponent('collision', { type: 'box' });
+        block.addComponent('rigidbody', { type: 'static' });
+        block.setLocalScale(cellSize, cellSize, cellSize);
+        block.setLocalPosition(offsetX + x * cellSize, 0, offsetZ + y * cellSize);
+        app.root.addChild(block);
+      }
+    }
+  }
+
+  const spawnPos = new pc.Vec3(
+    offsetX + level.spawn.x * cellSize,
+    cellSize / 2,
+    offsetZ + level.spawn.y * cellSize
+  );
+
+  const goal = new pc.Entity('goal');
+  goal.addComponent('render', { type: 'box' });
+  goal.setLocalScale(cellSize, cellSize, cellSize);
+  goal.setLocalPosition(
+    offsetX + level.goal.x * cellSize,
+    cellSize / 2,
+    offsetZ + level.goal.y * cellSize
+  );
+  app.root.addChild(goal);
+
+  const enemies: pc.Vec3[] = [];
+  if (level.enemies) {
+    for (const e of level.enemies) {
+      enemies.push(
+        new pc.Vec3(
+          offsetX + e.x * cellSize,
+          cellSize / 2,
+          offsetZ + e.y * cellSize
+        )
+      );
+    }
+  }
+
+  return { spawn: spawnPos, goal, enemies };
+}
+
+export async function createPlayer(
+  app: pc.Application,
+  position: pc.Vec3
+): Promise<pc.Entity> {
+  const player = await loadGlb(app, playerModelUrl);
+  player.name = 'player';
+  player.addComponent('collision', { type: 'box' });
+  player.addComponent('rigidbody', { mass: 1 });
+  player.setLocalPosition(position);
+  app.root.addChild(player);
+  return player;
+}
+
+export function createEnemy(
+  app: pc.Application,
+  position: pc.Vec3
+): pc.Entity {
+  const mat = new pc.StandardMaterial();
+  mat.diffuse.set(1, 0, 0);
+  mat.update();
+  const enemy = new pc.Entity('enemy');
+  enemy.addComponent('render', { type: 'capsule', material: mat });
+  enemy.addComponent('collision', { type: 'capsule', radius: 0.25, height: 1 });
+  enemy.addComponent('rigidbody', { type: 'kinematic' });
+  enemy.setLocalPosition(position);
+  app.root.addChild(enemy);
+  return enemy;
 }

--- a/src/level-designer.ts
+++ b/src/level-designer.ts
@@ -1,0 +1,53 @@
+import { LevelData } from './game-engine';
+
+export class LevelDesigner {
+  private width: number;
+  private height: number;
+  private grid: string[];
+  private spawn = { x: 0, y: 0 };
+  private goal = { x: 0, y: 0 };
+  private enemies: { x: number; y: number }[] = [];
+
+  constructor(width: number, height: number) {
+    this.width = width;
+    this.height = height;
+    this.grid = Array.from({ length: height }, () => '.'.repeat(width));
+  }
+
+  setBlock(x: number, y: number): void {
+    this.setCell(x, y, 'S');
+  }
+
+  clearCell(x: number, y: number): void {
+    this.setCell(x, y, '.');
+  }
+
+  private setCell(x: number, y: number, ch: string): void {
+    const row = this.grid[y].split('');
+    row[x] = ch;
+    this.grid[y] = row.join('');
+  }
+
+  setSpawn(x: number, y: number): void {
+    this.spawn = { x, y };
+  }
+
+  setGoal(x: number, y: number): void {
+    this.goal = { x, y };
+  }
+
+  addEnemy(x: number, y: number): void {
+    this.enemies.push({ x, y });
+  }
+
+  build(): LevelData {
+    return {
+      width: this.width,
+      height: this.height,
+      grid: this.grid,
+      spawn: this.spawn,
+      goal: this.goal,
+      enemies: this.enemies
+    };
+  }
+}

--- a/src/test-canvas.ts
+++ b/src/test-canvas.ts
@@ -1,5 +1,13 @@
 import * as pc from 'playcanvas';
-import { initAmmo, createApp } from './game-engine';
+import {
+  initAmmo,
+  createApp,
+  buildLevel,
+  createPlayer,
+  createEnemy,
+  LevelData
+} from './game-engine';
+import { LevelDesigner } from './level-designer';
 
 const canvas = document.getElementById('canvas') as HTMLCanvasElement;
 
@@ -7,22 +15,62 @@ async function main() {
   await initAmmo();
   const app = createApp(canvas);
 
-  if (!app.systems.rigidbody) {
-    console.error('RigidBody system missing');
-    return;
+  const designer = new LevelDesigner(5, 5);
+  for (let i = 0; i < 5; i++) {
+    designer.setBlock(i, 0);
+    designer.setBlock(i, 4);
+    designer.setBlock(0, i);
+    designer.setBlock(4, i);
   }
+  designer.setSpawn(2, 2);
+  designer.setGoal(2, 4);
+  designer.addEnemy(1, 3);
+  const levelData: LevelData = designer.build();
 
-  const ground = new pc.Entity('ground');
-  ground.addComponent('render', { type: 'box' });
-  ground.addComponent('rigidbody', { type: 'static', restitution: 0.5 });
-  ground.setLocalScale(10, 1, 10);
-  app.root.addChild(ground);
+  const light = new pc.Entity('light');
+  light.addComponent('light', { type: 'directional', intensity: 1 });
+  light.setLocalEulerAngles(45, 45, 0);
+  app.root.addChild(light);
 
-  const box = new pc.Entity('box');
-  box.addComponent('render', { type: 'box' });
-  box.addComponent('rigidbody', { mass: 1 });
-  box.setLocalPosition(0, 5, 0);
-  app.root.addChild(box);
+  const { spawn, goal, enemies: enemySpawns } = buildLevel(app, levelData);
+  const player = await createPlayer(app, spawn);
+  const enemies = enemySpawns.map((pos) => createEnemy(app, pos));
+
+  const camera = new pc.Entity('camera');
+  camera.addComponent('camera', {
+    clearColor: new pc.Color().fromString(
+      levelData.palette?.background || '#000000'
+    )
+  });
+  app.root.addChild(camera);
+
+  app.on('update', () => {
+    const force = new pc.Vec3();
+    const speed = 5;
+    if (app.keyboard.isPressed(pc.KEY_W)) force.z -= speed;
+    if (app.keyboard.isPressed(pc.KEY_S)) force.z += speed;
+    if (app.keyboard.isPressed(pc.KEY_A)) force.x -= speed;
+    if (app.keyboard.isPressed(pc.KEY_D)) force.x += speed;
+    if (force.lengthSq() > 0) {
+      player.rigidbody.applyForce(force);
+    }
+
+    enemies.forEach((enemy) => {
+      const ep = enemy.getPosition();
+      enemy.setLocalPosition(ep.x + Math.sin(app.time) * 0.01, ep.y, ep.z);
+      if (ep.distance(player.getPosition()) < 0.5) {
+        console.log('Hit by enemy');
+      }
+    });
+
+    if (goal.getPosition().distance(player.getPosition()) < 0.5) {
+      console.log('Level complete');
+    }
+
+    const p = player.getPosition();
+    camera.setLocalPosition(p.x, p.y + 5, p.z + 10);
+    camera.lookAt(p);
+  });
 }
 
 main();


### PR DESCRIPTION
## Summary
- Add LevelDesigner utility to build levels with blocks, spawn, goal and enemies
- Extend engine with enemy factory and buildLevel returning enemy spawn positions
- Update demo to spawn moving enemies and check win/lose conditions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c531962388327b0c54a3077470d27