### PR TITLE
feat: parse level grid and add basic designer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+package-lock.json
+.env
+
+# build
+build/
+dist/
+

--- a/level-designer.html
+++ b/level-designer.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Level Designer</title>
+    <style>
+      #editor { width: max-content; margin-bottom: 1em; }
+      #editor button { width:30px; height:30px; }
+    </style>
+  </head>
+  <body>
+    <div id="editor"></div>
+    <button id="export">Export</button>
+    <script type="module" src="/src/level-designer-app.ts"></script>
+  </body>
+</html>

--- a/levels/level1.json
+++ b/levels/level1.json
@@ -7,7 +7,7 @@
     "SSSSS",
     "S...S",
     "S.P.S",
-    "S...S",
+    "S.E.S",
     "SSGSS"
   ],
   "theme": "starter",
@@ -17,8 +17,5 @@
     "accent": "#ff0000"
   },
   "skybox": { "url": "/assets/skyboxes/level1.jpg", "source": "user" },
-  "spawn": { "x": 2, "y": 2 },
-  "goal": { "x": 2, "y": 4 },
-  "entities": [],
   "meta": { "difficulty": "easy", "version": 1 }
 }

--- a/src/game-engine.ts
+++ b/src/game-engine.ts
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import playerModelUrl from './player.glb?url';
 
 export async function initAmmo(): Promise<void> {
   pc.WasmModule.setConfig('Ammo', {
@@ -22,4 +23,145 @@ export function createApp(canvas: HTMLCanvasElement): pc.Application {
 
   app.start();
   return app;
+}
+
+async function loadGlb(app: pc.Application, url: string): Promise<pc.Entity> {
+  return await new Promise((resolve, reject) => {
+    app.assets.loadFromUrl(url, 'container', (err, asset) => {
+      if (err || !asset) {
+        reject(err);
+        return;
+      }
+      const entity = (asset as pc.Asset).resource.instantiateRenderEntity();
+      resolve(entity);
+    });
+  });
+}
+
+export interface LevelData {
+  width: number;
+  height: number;
+  grid: string[];
+  spawn?: { x: number; y: number };
+  goal?: { x: number; y: number };
+  enemies?: { x: number; y: number }[];
+  palette?: { background?: string; primary?: string; accent?: string };
+  theme?: string;
+  skybox?: { url: string; source: string };
+  meta?: Record<string, unknown>;
+}
+
+export function buildLevel(
+  app: pc.Application,
+  level: LevelData
+): { spawn: pc.Vec3; goal: pc.Entity; enemies: pc.Vec3[] } {
+  const cellSize = 1;
+  const offsetX = -(level.width * cellSize) / 2 + cellSize / 2;
+  const offsetZ = -(level.height * cellSize) / 2 + cellSize / 2;
+
+  const enemies: pc.Vec3[] = [];
+  let spawnPos: pc.Vec3 | null = null;
+  let goal: pc.Entity | null = null;
+
+  for (let y = 0; y < level.height; y++) {
+    const row = level.grid[y];
+    for (let x = 0; x < level.width; x++) {
+      const ch = row[x];
+      const worldPos = new pc.Vec3(
+        offsetX + x * cellSize,
+        cellSize / 2,
+        offsetZ + y * cellSize
+      );
+      switch (ch) {
+        case 'S': {
+          const block = new pc.Entity(`block-${x}-${y}`);
+          block.addComponent('render', { type: 'box' });
+          block.addComponent('collision', { type: 'box' });
+          block.addComponent('rigidbody', { type: 'static' });
+          block.setLocalScale(cellSize, cellSize, cellSize);
+          block.setLocalPosition(worldPos);
+          app.root.addChild(block);
+          break;
+        }
+        case 'P':
+          spawnPos = worldPos.clone();
+          break;
+        case 'G':
+          goal = new pc.Entity('goal');
+          goal.addComponent('render', { type: 'box' });
+          goal.setLocalScale(cellSize, cellSize, cellSize);
+          goal.setLocalPosition(worldPos);
+          app.root.addChild(goal);
+          break;
+        case 'E':
+          enemies.push(worldPos.clone());
+          break;
+      }
+    }
+  }
+
+  if (!spawnPos && level.spawn) {
+    spawnPos = new pc.Vec3(
+      offsetX + level.spawn.x * cellSize,
+      cellSize / 2,
+      offsetZ + level.spawn.y * cellSize
+    );
+  }
+  if (!goal && level.goal) {
+    goal = new pc.Entity('goal');
+    goal.addComponent('render', { type: 'box' });
+    goal.setLocalScale(cellSize, cellSize, cellSize);
+    goal.setLocalPosition(
+      offsetX + level.goal.x * cellSize,
+      cellSize / 2,
+      offsetZ + level.goal.y * cellSize
+    );
+    app.root.addChild(goal);
+  }
+  if (level.enemies) {
+    for (const e of level.enemies) {
+      enemies.push(
+        new pc.Vec3(
+          offsetX + e.x * cellSize,
+          cellSize / 2,
+          offsetZ + e.y * cellSize
+        )
+      );
+    }
+  }
+
+  if (!spawnPos || !goal) {
+    throw new Error('Level is missing spawn or goal');
+  }
+
+  return { spawn: spawnPos, goal, enemies };
+}
+
+export async function createPlayer(
+  app: pc.Application,
+  position: pc.Vec3
+): Promise<pc.Entity> {
+  const player = await loadGlb(app, playerModelUrl);
+  player.name = 'player';
+  player.addComponent('collision', { type: 'box' });
+  player.addComponent('rigidbody', { mass: 1 });
+  player.setLocalPosition(position);
+  app.root.addChild(player);
+  return player;
+}
+
+export function createEnemy(
+  app: pc.Application,
+  position: pc.Vec3
+): pc.Entity {
+  const mat = new pc.StandardMaterial();
+  mat.diffuse.set(1, 0, 0);
+  mat.update();
+  const enemy = new pc.Entity('enemy');
+  enemy.addComponent('render', { type: 'capsule', material: mat });
+  enemy.addComponent('collision', { type: 'capsule', radius: 0.25, height: 1 });
+  enemy.addComponent('rigidbody', { type: 'kinematic' });
+  enemy.setLocalPosition(position);
+  app.root.addChild(enemy);
+  return enemy;
 }

--- a/src/level-designer-app.ts
+++ b/src/level-designer-app.ts
@@ -1,0 +1,56 @@
+import { LevelDesigner } from './level-designer';
+import { LevelData } from './game-engine';
+
+const size = 8;
+const designer = new LevelDesigner(size, size);
+
+const editor = document.getElementById('editor') as HTMLElement;
+editor.style.display = 'grid';
+editor.style.gridTemplateColumns = `repeat(${size}, 30px)`;
+
+const states = ['.', 'S', 'P', 'G', 'E'];
+
+for (let y = 0; y < size; y++) {
+  for (let x = 0; x < size; x++) {
+    const cell = document.createElement('button');
+    cell.style.width = '30px';
+    cell.style.height = '30px';
+    cell.dataset.state = '0';
+    cell.dataset.x = String(x);
+    cell.dataset.y = String(y);
+    cell.addEventListener('click', () => {
+      const cx = Number(cell.dataset.x);
+      const cy = Number(cell.dataset.y);
+      const idx = Number(cell.dataset.state);
+      const next = (idx + 1) % states.length;
+      cell.dataset.state = String(next);
+      const ch = states[next];
+      cell.textContent = ch === '.' ? '' : ch;
+      switch (ch) {
+        case 'S':
+          designer.setBlock(cx, cy);
+          break;
+        case 'P':
+          designer.setSpawn(cx, cy);
+          break;
+        case 'G':
+          designer.setGoal(cx, cy);
+          break;
+        case 'E':
+          designer.addEnemy(cx, cy);
+          break;
+        default:
+          designer.clearCell(cx, cy);
+      }
+    });
+    editor.appendChild(cell);
+  }
+}
+
+(document.getElementById('export') as HTMLButtonElement).addEventListener(
+  'click',
+  () => {
+    const data: LevelData = designer.build();
+    console.log(JSON.stringify(data, null, 2));
+  }
+);

--- a/src/level-designer.ts
+++ b/src/level-designer.ts
@@ -1,0 +1,76 @@
+import { LevelData } from './game-engine';
+
+/**
+ * Simple in-memory level designer that lets callers mark cells and export a
+ * {@link LevelData} object. The grid uses the following characters:
+ * - `S` for solid blocks
+ * - `P` for player spawn
+ * - `G` for the level goal
+ * - `E` for enemy spawns
+ * - `.` for empty space
+ */
+export class LevelDesigner {
+  private width: number;
+  private height: number;
+  private grid: string[];
+
+  constructor(width: number, height: number) {
+    this.width = width;
+    this.height = height;
+    this.grid = Array.from({ length: height }, () => '.'.repeat(width));
+  }
+
+  /** Mark a cell as a solid block. */
+  setBlock(x: number, y: number): void {
+    this.setCell(x, y, 'S');
+  }
+
+  /** Remove any object from a cell. */
+  clearCell(x: number, y: number): void {
+    this.setCell(x, y, '.');
+  }
+
+  /** Set the player spawn position. */
+  setSpawn(x: number, y: number): void {
+    this.setCell(x, y, 'P');
+  }
+
+  /** Set the goal position. */
+  setGoal(x: number, y: number): void {
+    this.setCell(x, y, 'G');
+  }
+
+  /** Add an enemy spawn point at the given cell. */
+  addEnemy(x: number, y: number): void {
+    this.setCell(x, y, 'E');
+  }
+
+  private setCell(x: number, y: number, ch: string): void {
+    const row = this.grid[y].split('');
+    row[x] = ch;
+    this.grid[y] = row.join('');
+  }
+
+  /**
+   * Build a {@link LevelData} object by scanning the grid for special cells.
+   */
+  build(): LevelData {
+    const data: LevelData = {
+      width: this.width,
+      height: this.height,
+      grid: this.grid.slice()
+    } as LevelData;
+
+    const enemies: { x: number; y: number }[] = [];
+    for (let y = 0; y < this.height; y++) {
+      for (let x = 0; x < this.width; x++) {
+        const ch = this.grid[y][x];
+        if (ch === 'P') data.spawn = { x, y };
+        else if (ch === 'G') data.goal = { x, y };
+        else if (ch === 'E') enemies.push({ x, y });
+      }
+    }
+    if (enemies.length > 0) data.enemies = enemies;
+    return data;
+  }
+}

--- a/src/test-canvas.ts
+++ b/src/test-canvas.ts
@@ -1,5 +1,12 @@
 import * as pc from 'playcanvas';
-import { initAmmo, createApp } from './game-engine';
+import {
+  initAmmo,
+  createApp,
+  buildLevel,
+  createPlayer,
+  createEnemy,
+  LevelData
+} from './game-engine';
 
 const canvas = document.getElementById('canvas') as HTMLCanvasElement;
 
@@ -7,22 +14,54 @@ async function main() {
   await initAmmo();
   const app = createApp(canvas);
 
-  if (!app.systems.rigidbody) {
-    console.error('RigidBody system missing');
-    return;
-  }
+  const levelData: LevelData = await fetch('/levels/level1.json').then((r) =>
+    r.json()
+  );
 
-  const ground = new pc.Entity('ground');
-  ground.addComponent('render', { type: 'box' });
-  ground.addComponent('rigidbody', { type: 'static', restitution: 0.5 });
-  ground.setLocalScale(10, 1, 10);
-  app.root.addChild(ground);
+  const light = new pc.Entity('light');
+  light.addComponent('light', { type: 'directional', intensity: 1 });
+  light.setLocalEulerAngles(45, 45, 0);
+  app.root.addChild(light);
 
-  const box = new pc.Entity('box');
-  box.addComponent('render', { type: 'box' });
-  box.addComponent('rigidbody', { mass: 1 });
-  box.setLocalPosition(0, 5, 0);
-  app.root.addChild(box);
+  const { spawn, goal, enemies: enemySpawns } = buildLevel(app, levelData);
+  const player = await createPlayer(app, spawn);
+  const enemies = enemySpawns.map((pos) => createEnemy(app, pos));
+
+  const camera = new pc.Entity('camera');
+  camera.addComponent('camera', {
+    clearColor: new pc.Color().fromString(
+      levelData.palette?.background || '#000000'
+    )
+  });
+  app.root.addChild(camera);
+
+  app.on('update', () => {
+    const force = new pc.Vec3();
+    const speed = 5;
+    if (app.keyboard.isPressed(pc.KEY_W)) force.z -= speed;
+    if (app.keyboard.isPressed(pc.KEY_S)) force.z += speed;
+    if (app.keyboard.isPressed(pc.KEY_A)) force.x -= speed;
+    if (app.keyboard.isPressed(pc.KEY_D)) force.x += speed;
+    if (force.lengthSq() > 0) {
+      player.rigidbody.applyForce(force);
+    }
+
+    enemies.forEach((enemy) => {
+      const ep = enemy.getPosition();
+      enemy.setLocalPosition(ep.x + Math.sin(app.time) * 0.01, ep.y, ep.z);
+      if (ep.distance(player.getPosition()) < 0.5) {
+        console.log('Hit by enemy');
+      }
+    });
+
+    if (goal.getPosition().distance(player.getPosition()) < 0.5) {
+      console.log('Level complete');
+    }
+
+    const p = player.getPosition();
+    camera.setLocalPosition(p.x, p.y + 5, p.z + 10);
+    camera.lookAt(p);
+  });
 }
 
 main();


### PR DESCRIPTION
## Summary
- Parse spawn, goal and enemy positions directly from the level grid and support extra metadata
- Provide a simple in-browser level designer utility and example HTML page
- Load levels from JSON in the sample canvas and use player/enemy factories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c531962388327b0c54a3077470d27