### PR TITLE
refactor: clean level designer and build logic

### DIFF
--- a/src/game-engine.ts
+++ b/src/game-engine.ts
@@ -118,48 +118,6 @@ export function buildLevel(
     );
     app.root.addChild(goal);
   }
-=======
-      if (ch === 'S') {
-        const block = new pc.Entity(`block-${x}-${y}`);
-        block.addComponent('render', { type: 'box' });
-        block.addComponent('collision', { type: 'box' });
-        block.addComponent('rigidbody', { type: 'static' });
-        block.setLocalScale(cellSize, cellSize, cellSize);
-        block.setLocalPosition(offsetX + x * cellSize, 0, offsetZ + y * cellSize);
-        app.root.addChild(block);
-      }
-    }
-  }
-
-  const spawnPos = new pc.Vec3(
-    offsetX + level.spawn.x * cellSize,
-    cellSize / 2,
-    offsetZ + level.spawn.y * cellSize
-  );
-
-  const goal = new pc.Entity('goal');
-  goal.addComponent('render', { type: 'box' });
-  goal.setLocalScale(cellSize, cellSize, cellSize);
-  goal.setLocalPosition(
-    offsetX + level.goal.x * cellSize,
-    cellSize / 2,
-    offsetZ + level.goal.y * cellSize
-  );
-  app.root.addChild(goal);
-
-  const enemies: pc.Vec3[] = [];
-  if (level.enemies) {
-    for (const e of level.enemies) {
-      enemies.push(
-        new pc.Vec3(
-          offsetX + e.x * cellSize,
-          cellSize / 2,
-          offsetZ + e.y * cellSize
-        )
-      );
-    }
-  }
-
   if (!spawnPos || !goal) {
     throw new Error('Level is missing spawn or goal');
   }

--- a/src/level-designer.ts
+++ b/src/level-designer.ts
@@ -1,8 +1,7 @@
 import { LevelData } from './game-engine';
 
 /**
- * Simple in-memory level designer that lets callers mark cells and export a
- * {@link LevelData} object. The grid uses the following characters:
+ * In-memory level designer backed by a grid of characters. The grid uses:
  * - `S` for solid blocks
  * - `P` for player spawn
  * - `G` for the level goal
@@ -10,16 +9,8 @@ import { LevelData } from './game-engine';
  * - `.` for empty space
  */
 export class LevelDesigner {
-  private width: number;
-  private height: number;
   private grid: string[];
-  private spawn = { x: 0, y: 0 };
-  private goal = { x: 0, y: 0 };
-  private enemies: { x: number; y: number }[] = [];
-
-  constructor(width: number, height: number) {
-    this.width = width;
-    this.height = height;
+  constructor(private width: number, private height: number) {
     this.grid = Array.from({ length: height }, () => '.'.repeat(width));
   }
 
@@ -33,13 +24,15 @@ export class LevelDesigner {
     this.setCell(x, y, '.');
   }
 
-  /** Set the player spawn position. */
+  /** Set the player spawn position, clearing any previous spawn. */
   setSpawn(x: number, y: number): void {
+    this.clearAll('P');
     this.setCell(x, y, 'P');
   }
 
-  /** Set the goal position. */
+  /** Set the goal position, clearing any previous goal. */
   setGoal(x: number, y: number): void {
+    this.clearAll('G');
     this.setCell(x, y, 'G');
   }
 
@@ -54,9 +47,13 @@ export class LevelDesigner {
     this.grid[y] = row.join('');
   }
 
-  /**
-   * Build a {@link LevelData} object by scanning the grid for special cells.
-   */
+  private clearAll(ch: string): void {
+    for (let y = 0; y < this.height; y++) {
+      this.grid[y] = this.grid[y].replace(ch, '.');
+    }
+  }
+
+  /** Build a {@link LevelData} object by scanning the grid for special cells. */
   build(): LevelData {
     const data: LevelData = {
       width: this.width,
@@ -75,32 +72,5 @@ export class LevelDesigner {
     }
     if (enemies.length > 0) data.enemies = enemies;
     return data;
-  private setCell(x: number, y: number, ch: string): void {
-    const row = this.grid[y].split('');
-    row[x] = ch;
-    this.grid[y] = row.join('');
-  }
-
-  setSpawn(x: number, y: number): void {
-    this.spawn = { x, y };
-  }
-
-  setGoal(x: number, y: number): void {
-    this.goal = { x, y };
-  }
-
-  addEnemy(x: number, y: number): void {
-    this.enemies.push({ x, y });
-  }
-
-  build(): LevelData {
-    return {
-      width: this.width,
-      height: this.height,
-      grid: this.grid,
-      spawn: this.spawn,
-      goal: this.goal,
-      enemies: this.enemies
-    };
   }
 }

--- a/src/test-canvas.ts
+++ b/src/test-canvas.ts
@@ -13,10 +13,6 @@ const canvas = document.getElementById('canvas') as HTMLCanvasElement;
 async function main() {
   await initAmmo();
   const app = createApp(canvas);
-
-  const levelData: LevelData = await fetch('/levels/level1.json').then((r) =>
-    r.json()
-  );
   const designer = new LevelDesigner(5, 5);
   for (let i = 0; i < 5; i++) {
     designer.setBlock(i, 0);


### PR DESCRIPTION
## Summary
- rebuild LevelDesigner with grid-based editing and data export
- simplify buildLevel to parse grid and validate spawn and goal
- update test canvas to generate level data with LevelDesigner

## Testing
- `npm test`
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_689c6e47044c8327b6a4cf9bd6f2c18a